### PR TITLE
Fix issue with missing LEARNING_MICROFRONTEND_URL for keyterms-xblock.

### DIFF
--- a/tutormfe/patches/openedx-cms-production-settings
+++ b/tutormfe/patches/openedx-cms-production-settings
@@ -1,0 +1,16 @@
+{% if MFE_ACCOUNT_MFE_APP %}
+ACCOUNT_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/{{ MFE_ACCOUNT_MFE_APP["name"] }}"
+{% endif %}
+{% if MFE_GRADEBOOK_MFE_APP %}
+WRITABLE_GRADEBOOK_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/{{ MFE_GRADEBOOK_MFE_APP["name"] }}"
+{% endif %}
+{% if MFE_LEARNING_MFE_APP %}
+LEARNING_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/{{ MFE_LEARNING_MFE_APP["name"] }}"
+{% endif %}
+{% if MFE_PROFILE_MFE_APP %}
+PROFILE_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}/{{ MFE_PROFILE_MFE_APP["name"] }}/u/"
+{% endif %}
+
+LOGIN_REDIRECT_WHITELIST.append("{{ MFE_HOST }}")
+CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ MFE_HOST }}")
+CSRF_TRUSTED_ORIGINS.append("{{ MFE_HOST }}")


### PR DESCRIPTION
Todo: 
May want to remove this change later because this commit is related to MFE.
https://github.com/CUCWD/tutor-educateworkforce-config/pull/19