### PR TITLE
Setup plugin to account for load balancing changes: Push MFE npm build output to S3 bucket.

### DIFF
--- a/tutormfe/plugin.py
+++ b/tutormfe/plugin.py
@@ -13,6 +13,16 @@ config = {
         "HOST": "apps.{{ LMS_HOST }}",
         "COMMON_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
         "CADDY_DOCKER_IMAGE": "{{ DOCKER_IMAGE_CADDY }}",
+        # S3 MFE Staticfiles
+        # ----------------------
+        # The bucket name to use for S3 static files
+        "STATIC_FILES_BUCKET_NAME": "SET_ME_PLEASE",
+        # AWS S3 settings
+        "AWS_STATIC_FILES_ACCESS_KEY_ID": "SET_ME_PLEASE",
+        "AWS_STATIC_FILES_SECRET_KEY": "SET_ME_PLEASE",
+        "DEPLOY_S3": False,
+        # MFE App Settings
+        # ----------------------
         "ACCOUNT_MFE_APP": {
             "name": "account",
             "repository": "https://github.com/edx/frontend-app-account",

--- a/tutormfe/templates/mfe/build/mfe/Dockerfile
+++ b/tutormfe/templates/mfe/build/mfe/Dockerfile
@@ -50,7 +50,8 @@ RUN npm clean-install --no-audit --no-fund --registry=$NPM_REGISTRY \
 {{ patch("mfe-dockerfile-post-npm-install") }}
 COPY --from={{ app["name"] }}-src /openedx/app /openedx/app
 COPY --from={{ app["name"] }}-i18n /openedx/app/src/i18n/messages /openedx/app/src/i18n/messages
-ENV PUBLIC_PATH='/{{ app["name"] }}/'
+ENV PUBLIC_PATH='https://{{ MFE_PUBLIC_PATH }}/{{ app["name"] }}/'
+# ENV PUBLIC_PATH='/{{ app["name"] }}/'
 EXPOSE {{ app['port'] }}
 CMD ["npm", "run", "start"]
 ######## {{ app["name"] }} (production)
@@ -62,8 +63,28 @@ RUN touch /openedx/env/production.override \
   {%- endfor %}
   && echo "done setting production overrides"
 RUN bash -c "set -a && source /openedx/env/production && source /openedx/env/production.override && npm run build"
+
+{% if MFE_DEPLOY_S3 %}
+######## {{ app["name"] }} (skilredi-upload-static-files-to-s3)
+FROM {{ app["name"] }} AS {{ app["name"] }}-upload-static-files-to-s3
+
+# Install aws cli
+RUN apt install -y curl unzip && \
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip awscliv2.zip && \
+  ./aws/install --bin-dir /openedx/bin --install-dir /openedx/aws-cli && rm -r aws awscliv2.zip
+
+# Copy AWS CLI credentials.
+RUN mkdir -p /root/.aws/
+COPY ./aws/config /root/.aws/config
+COPY ./aws/credentials /root/.aws/credentials
+
+RUN /openedx/aws-cli/v2/current/bin/aws --profile s3-uploader s3 sync --delete --follow-symlinks /openedx/app/dist/ s3://{{ MFE_STATIC_FILES_BUCKET_NAME }}/{{ app["name"] }}/
+{% endif %}
+
 {% endfor %}
 
+{% if not MFE_DEPLOY_S3 %}
 ####### final production image with all static assets
 FROM {{ MFE_CADDY_DOCKER_IMAGE }} as production
 
@@ -76,3 +97,4 @@ COPY --from={{ app["name"] }} /openedx/app/dist /openedx/dist/{{ app["name"] }}
 
 # Copy caddy config file
 COPY ./Caddyfile /etc/caddy/Caddyfile
+{% endif %}

--- a/tutormfe/templates/mfe/build/mfe/aws/config
+++ b/tutormfe/templates/mfe/build/mfe/aws/config
@@ -1,0 +1,4 @@
+# Profile for S3 upload
+[profile s3-uploader]
+region=us-east-1
+output=json

--- a/tutormfe/templates/mfe/build/mfe/aws/credentials
+++ b/tutormfe/templates/mfe/build/mfe/aws/credentials
@@ -1,0 +1,4 @@
+# Profile for S3 uploader
+[s3-uploader]
+aws_access_key_id = {{ MFE_AWS_STATIC_FILES_ACCESS_KEY_ID }}
+aws_secret_access_key = {{ MFE_AWS_STATIC_FILES_SECRET_KEY }}


### PR DESCRIPTION
When setting the `MFE_DEPLOY_S3` tutor environment variable to true, this will send all publish `npm build` files for this MFE to the S3 bucket defined at `MFE_STATIC_FILES_BUCKET_NAME`.
